### PR TITLE
fix/gh pages 6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       pages: write
       id-token: write
     container:
-      image: barichello/godot-ci:{{GODOT_VERSION}}
+      image: barichello/godot-ci:${GODOT_VERSION}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- **use godot 4.5 for building**
- **use a variable for GODOT_VERSION**
- **use the correct variable reference**
